### PR TITLE
Cross build for Scala 2.10 and 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ version := "1.5-SNAPSHOT"
 
 scalaVersion := "2.10.4"
 
+crossScalaVersions := Seq("2.10.4", "2.11.2")
+
 exportJars := true
 
 exportJars in Test := false

--- a/makefile
+++ b/makefile
@@ -16,17 +16,17 @@ all: compile test
 
 .PHONY: stage
 stage:
-	sbt stage
+	sbt +stage
 
 .PHONY: publish
 publish:
-	sbt publish
+	sbt +publish
 
 .PHONY: publish-signed
 publish-signed:
 	@echo GPG_AGENT_INFO: $(value GPG_AGENT_INFO)
 	@echo SONATYPE_USERNAME: $(value SONATYPE_USERNAME)
-	sbt publish-signed
+	sbt +publish-signed
 
 .PHONY: cleanpackage
 cleanpackage:


### PR DESCRIPTION
Makes relate available to Scala 2.10 and 2.11 code.

Prepending "+" to an sbt commands evaluates it for both Scala versions, e.g. `sbt +compile`, or `sbt +publish`.

Resolves https://github.com/lucidsoftware/relate/issues/4.
