### PR TITLE
Move MySQL dependency to the it scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ retrieveManaged := true
 libraryDependencies ++= Seq(
   "org.specs2" %% "specs2" % "2.3.12" % "it",
   "org.specs2" %% "specs2" % "2.3.12" % "test",
-  "mysql" % "mysql-connector-java" % "5.1.23"
+  "mysql" % "mysql-connector-java" % "5.1.23" % "it"
 )
 
 pomExtra := (


### PR DESCRIPTION
Relate is DB independent, so we shouldn't be publishing any JDBC implementations.
