### PR TITLE
API improvement: remove RowParser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ exportJars in Test := false
 
 autoScalaLibrary := true
 
+scalacOptions += "-deprecation"
+
 retrieveManaged := true
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/com/lucidchart/open/relate/PaginatedQuery.scala
+++ b/src/main/scala/com/lucidchart/open/relate/PaginatedQuery.scala
@@ -28,7 +28,7 @@ object PaginatedQuery {
    * @return a Stream over all the records returned by the query, getting a new page of results
    * when the current one is exhausted
    */
-  def apply[A](parser: RowParser[A])(getNextStmt: Option[A] => Sql)(implicit connection: Connection): Stream[A] = {
+  def apply[A](parser: SqlResult => A)(getNextStmt: Option[A] => Sql)(implicit connection: Connection): Stream[A] = {
     new PaginatedQuery(parser, connection).withQuery(getNextStmt)
   }
 
@@ -44,7 +44,7 @@ object PaginatedQuery {
    * @return a Stream over all the records returned by the query, getting a new page of results
    * when the current one is exhausted
    */
-  def apply[A](parser: RowParser[A], limit: Int, startingOffset: Long)(query: ParameterizedSql)(implicit connection: Connection): Stream[A] = {
+  def apply[A](parser: SqlResult => A, limit: Int, startingOffset: Long)(query: ParameterizedSql)(implicit connection: Connection): Stream[A] = {
     new PaginatedQuery(parser, connection).withLimitAndOffset(limit, startingOffset, query)
   }
 }
@@ -52,7 +52,7 @@ object PaginatedQuery {
 /**
  * A query object that will execute a query in a paginated format and return the results in a Stream
  */
-private[relate] class PaginatedQuery[A](parser: RowParser[A], connection: Connection) {
+private[relate] class PaginatedQuery[A](parser: SqlResult => A, connection: Connection) {
   self =>
 
   /**

--- a/src/main/scala/com/lucidchart/open/relate/RowIterator.scala
+++ b/src/main/scala/com/lucidchart/open/relate/RowIterator.scala
@@ -3,10 +3,10 @@ package com.lucidchart.open.relate
 import java.sql.PreparedStatement
 
 private[relate] object RowIterator {
-  def apply[A](parser: RowParser[A], stmt: PreparedStatement, resultSet: SqlResult) = new RowIterator(parser, stmt, resultSet)
+  def apply[A](parser: SqlResult => A, stmt: PreparedStatement, resultSet: SqlResult) = new RowIterator(parser, stmt, resultSet)
 }
 
-private[relate] class RowIterator[A](parser: RowParser[A], stmt: PreparedStatement, result: SqlResult) extends Iterator[A] {
+private[relate] class RowIterator[A](parser: SqlResult => A, stmt: PreparedStatement, result: SqlResult) extends Iterator[A] {
 
   private var _hasNext = result.next()
 

--- a/src/main/scala/com/lucidchart/open/relate/RowParser.scala
+++ b/src/main/scala/com/lucidchart/open/relate/RowParser.scala
@@ -5,7 +5,9 @@ package com.lucidchart.open.relate
  * return a concrete type
  *
  * See the [[com.lucidchart.open.relate.RowParser$#apply RowParser]] for more information
+ *
  */
+@deprecated("Use plain SqlResult => A instead", "1.7.0")
 trait RowParser[+A] extends (SqlResult => A)
 
 /**
@@ -13,7 +15,7 @@ trait RowParser[+A] extends (SqlResult => A)
  * {{{
  * import com.lucidchart.open.relate.RowParser
  *
- * val rowParser = RowParser { row =>
+ * val rowParser = (row: SqlResult) =>
  *   (row.long("id"), row.string("name"))
  * }
  * }}}
@@ -24,6 +26,7 @@ object RowParser {
    * a concrete type
    * @param f the function that will do the parsing
    */
+  @deprecated("Use plain SqlResult => A instead", "1.7.0")
   def apply[A](f: (SqlResult) => A) = new RowParser[A] {
     def apply(row: SqlResult) = f(row)
   }
@@ -33,32 +36,32 @@ object RowParser {
    * @param columnLabel the column name to extract
    * @param the extracted column value
    */
-  def bigInt(columnLabel: String) = RowParser { row => row.bigInt(columnLabel) }
+  def bigInt(columnLabel: String) = (row: SqlResult) => row.bigInt(columnLabel)
   /**
    * Shorthand for creating a RowParser that takes only a date column from the result set
    * @param columnLabel the column name to extract
    * @param the extracted column value
    */
-  def date(columnLabel: String) = RowParser { row => row.date(columnLabel) }
+  def date(columnLabel: String) = (row: SqlResult) => row.date(columnLabel)
   /**
    * Shorthand for creating a RowParser that takes only an int column from the result set
    * @param columnLabel the column name to extract
    * @param the extracted column value
    */
-  def int(columnLabel: String) = RowParser { row => row.int(columnLabel) }
+  def int(columnLabel: String) = (row: SqlResult) => row.int(columnLabel)
   /**
    * Shorthand for creating a RowParser that takes only a long column from the result set
    * @param columnLabel the column name to extract
    * @param the extracted column value
    */
-  def long(columnLabel: String) = RowParser { row => row.long(columnLabel) }
+  def long(columnLabel: String) = (row: SqlResult) => row.long(columnLabel)
   /**
    * Shorthand for creating a RowParser that takes only a string column from the result set
    * @param columnLabel the column name to extract
    * @param the extracted column value
    */
-  def string(columnLabel: String) = RowParser { row => row.string(columnLabel) }
+  def string(columnLabel: String) = (row: SqlResult) => row.string(columnLabel)
 
-  private[relate] val insertInt = RowParser { row => row.strictInt(1) }
-  private[relate] val insertLong = RowParser { row => row.strictLong(1) }
+  private[relate] val insertInt = (row: SqlResult) => row.strictInt(1)
+  private[relate] val insertLong = (row: SqlResult) => row.strictLong(1)
 }

--- a/src/main/scala/com/lucidchart/open/relate/SqlQuery.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlQuery.scala
@@ -337,7 +337,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the auto-incremented key
    */
-  def executeInsertSingle[U](parser: RowParser[U])(implicit connection: Connection): U = insertionStatement.execute(_.asSingle(parser))
+  def executeInsertSingle[U](parser: SqlResult => U)(implicit connection: Connection): U = insertionStatement.execute(_.asSingle(parser))
   
   /**
    * Execute the query and get the auto-incremented keys using a RowParser. Provided for the case
@@ -346,7 +346,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the auto-incremented keys
    */
-  def executeInsertCollection[U, T[_]](parser: RowParser[U])(implicit cbf: CanBuildFrom[T[U], U, T[U]], connection: Connection): T[U] = insertionStatement.execute(_.asCollection(parser))
+  def executeInsertCollection[U, T[_]](parser: SqlResult => U)(implicit cbf: CanBuildFrom[T[U], U, T[U]], connection: Connection): T[U] = insertionStatement.execute(_.asCollection(parser))
 
   /**
    * Execute this query and get back the result as a single record
@@ -354,7 +354,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as a single record
    */
-  def asSingle[A](parser: RowParser[A])(implicit connection: Connection): A = normalStatement.execute(_.asSingle(parser))
+  def asSingle[A](parser: SqlResult => A)(implicit connection: Connection): A = normalStatement.execute(_.asSingle(parser))
   
   /**
    * Execute this query and get back the result as an optional single record
@@ -362,7 +362,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as an optional single record
    */
-  def asSingleOption[A](parser: RowParser[A])(implicit connection: Connection): Option[A] = normalStatement.execute(_.asSingleOption(parser))
+  def asSingleOption[A](parser: SqlResult => A)(implicit connection: Connection): Option[A] = normalStatement.execute(_.asSingleOption(parser))
   
   /**
    * Execute this query and get back the result as a Set of records
@@ -370,7 +370,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as a Set of records
    */
-  def asSet[A](parser: RowParser[A])(implicit connection: Connection): Set[A] = normalStatement.execute(_.asSet(parser))
+  def asSet[A](parser: SqlResult => A)(implicit connection: Connection): Set[A] = normalStatement.execute(_.asSet(parser))
   
   /**
    * Execute this query and get back the result as a sequence of records
@@ -378,7 +378,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as a sequence of records
    */
-  def asSeq[A](parser: RowParser[A])(implicit connection: Connection): Seq[A] = normalStatement.execute(_.asSeq(parser))
+  def asSeq[A](parser: SqlResult => A)(implicit connection: Connection): Seq[A] = normalStatement.execute(_.asSeq(parser))
   
   /**
    * Execute this query and get back the result as an iterable of records
@@ -386,7 +386,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as an iterable of records
    */
-  def asIterable[A](parser: RowParser[A])(implicit connection: Connection): Iterable[A] = normalStatement.execute(_.asIterable(parser))
+  def asIterable[A](parser: SqlResult => A)(implicit connection: Connection): Iterable[A] = normalStatement.execute(_.asIterable(parser))
   
   /**
    * Execute this query and get back the result as a List of records
@@ -394,7 +394,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as a List of records
    */
-  def asList[A](parser: RowParser[A])(implicit connection: Connection): List[A] = normalStatement.execute(_.asList(parser))
+  def asList[A](parser: SqlResult => A)(implicit connection: Connection): List[A] = normalStatement.execute(_.asList(parser))
   
   /**
    * Execute this query and get back the result as a Map of records
@@ -403,7 +403,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as a Map of records
    */
-  def asMap[U, V](parser: RowParser[(U, V)])(implicit connection: Connection): Map[U, V] = normalStatement.execute(_.asMap(parser))
+  def asMap[U, V](parser: SqlResult => (U, V))(implicit connection: Connection): Map[U, V] = normalStatement.execute(_.asMap(parser))
   
   /**
    * Execute this query and get back the result as a single value. Assumes that there is only one
@@ -428,7 +428,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as an arbitrary collection of records
    */
-  def asCollection[U, T[_]](parser: RowParser[U])(implicit cbf: CanBuildFrom[T[U], U, T[U]], connection: Connection): T[U] = normalStatement.execute(_.asCollection(parser))
+  def asCollection[U, T[_]](parser: SqlResult => U)(implicit cbf: CanBuildFrom[T[U], U, T[U]], connection: Connection): T[U] = normalStatement.execute(_.asCollection(parser))
   
   /**
    * Execute this query and get back the result as an arbitrary collection of key value pairs
@@ -436,7 +436,7 @@ trait Sql {
    * @param connection the connection to use when executing the query
    * @return the results as an arbitrary collection of key value pairs
    */
-  def asPairCollection[U, V, T[_, _]](parser: RowParser[(U, V)])(implicit cbf: CanBuildFrom[T[U, V], (U, V), T[U, V]], connection: Connection): T[U, V] = normalStatement.execute(_.asPairCollection(parser))
+  def asPairCollection[U, V, T[_, _]](parser: SqlResult => (U, V))(implicit cbf: CanBuildFrom[T[U, V], (U, V), T[U, V]], connection: Connection): T[U, V] = normalStatement.execute(_.asPairCollection(parser))
   
   /**
    * The asIterator method returns an Iterator that will stream data out of the database.
@@ -448,7 +448,7 @@ trait Sql {
    * is MySQL, the fetchSize will always default to Int.MinValue, as MySQL's JDBC implementation
    * ignores all other fetchSize values and only streams if fetchSize is Int.MinValue
    */
-  def asIterator[A](parser: RowParser[A], fetchSize: Int = 100)(implicit connection: Connection): Iterator[A] = {
+  def asIterator[A](parser: SqlResult => A, fetchSize: Int = 100)(implicit connection: Connection): Iterator[A] = {
     val prepared = streamedStatement(fetchSize)
     prepared.execute(RowIterator(parser, prepared.stmt, _))
   }

--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -51,13 +51,13 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
     }
   }
 
-  def asSingle[A](parser: RowParser[A]): A = asCollection[A, Seq](parser, 1).head
-  def asSingleOption[A](parser: RowParser[A]): Option[A] = asCollection[A, Seq](parser, 1).headOption
-  def asSet[A](parser: RowParser[A]): Set[A] = asCollection[A, Set](parser, Long.MaxValue)
-  def asSeq[A](parser: RowParser[A]): Seq[A] = asCollection[A, Seq](parser, Long.MaxValue)
-  def asIterable[A](parser: RowParser[A]): Iterable[A] = asCollection[A, Iterable](parser, Long.MaxValue)
-  def asList[A](parser: RowParser[A]): List[A] = asCollection[A, List](parser, Long.MaxValue)
-  def asMap[U, V](parser: RowParser[(U, V)]): Map[U, V] = asPairCollection[U, V, Map](parser, Long.MaxValue)
+  def asSingle[A](parser: SqlResult => A): A = asCollection[A, Seq](parser, 1).head
+  def asSingleOption[A](parser: SqlResult => A): Option[A] = asCollection[A, Seq](parser, 1).headOption
+  def asSet[A](parser: SqlResult => A): Set[A] = asCollection[A, Set](parser, Long.MaxValue)
+  def asSeq[A](parser: SqlResult => A): Seq[A] = asCollection[A, Seq](parser, Long.MaxValue)
+  def asIterable[A](parser: SqlResult => A): Iterable[A] = asCollection[A, Iterable](parser, Long.MaxValue)
+  def asList[A](parser: SqlResult => A): List[A] = asCollection[A, List](parser, Long.MaxValue)
+  def asMap[U, V](parser: SqlResult => (U, V)): Map[U, V] = asPairCollection[U, V, Map](parser, Long.MaxValue)
   
   def asScalar[A](): A = asScalarOption.get
   def asScalarOption[A](): Option[A] = {
@@ -69,8 +69,8 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
     }
   }
 
-  def asCollection[U, T[_]](parser: RowParser[U])(implicit cbf: CanBuildFrom[T[U], U, T[U]]): T[U] = asCollection(parser, Long.MaxValue)
-  protected def asCollection[U, T[_]](parser: RowParser[U], maxRows: Long)(implicit cbf: CanBuildFrom[T[U], U, T[U]]): T[U] = {
+  def asCollection[U, T[_]](parser: SqlResult => U)(implicit cbf: CanBuildFrom[T[U], U, T[U]]): T[U] = asCollection(parser, Long.MaxValue)
+  protected def asCollection[U, T[_]](parser: SqlResult => U, maxRows: Long)(implicit cbf: CanBuildFrom[T[U], U, T[U]]): T[U] = {
     val builder = cbf()
 
     withResultSet { resultSet =>
@@ -82,8 +82,8 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
     builder.result
   }
 
-  def asPairCollection[U, V, T[_, _]](parser: RowParser[(U, V)])(implicit cbf: CanBuildFrom[T[U, V], (U, V), T[U, V]]): T[U, V] = asPairCollection(parser, Long.MaxValue)
-  protected def asPairCollection[U, V, T[_, _]](parser: RowParser[(U, V)], maxRows: Long)(implicit cbf: CanBuildFrom[T[U, V], (U, V), T[U, V]]): T[U, V] = {
+  def asPairCollection[U, V, T[_, _]](parser: SqlResult => (U, V))(implicit cbf: CanBuildFrom[T[U, V], (U, V), T[U, V]]): T[U, V] = asPairCollection(parser, Long.MaxValue)
+  protected def asPairCollection[U, V, T[_, _]](parser: SqlResult => (U, V), maxRows: Long)(implicit cbf: CanBuildFrom[T[U, V], (U, V), T[U, V]]): T[U, V] = {
     val builder = cbf()
 
     withResultSet { resultSet =>

--- a/src/test/scala/SqlResultSpec.scala
+++ b/src/test/scala/SqlResultSpec.scala
@@ -27,14 +27,14 @@ case class TestRecord(
 )
 
 class SqlResultSpec extends Specification with Mockito {
-  val parser = RowParser { implicit row =>
+  val parser = { implicit row: SqlResult =>
     TestRecord(
       long("id"),
       string("name")
     )
   }
 
-  val pairparser = RowParser { implicit row =>
+  val pairparser = { implicit row: SqlResult =>
     val id = long("id")
     id -> TestRecord(
       id,


### PR DESCRIPTION
`RowParser` is entirely unnecessary.

Rather than

```
SQL("SELECT * FROM pokemon").asList(RowParser { row =>
  Pokemon(row.string("name"), row.short("level"), row.longOption("trainer_id"))
})
```

we could instead have

```
SQL("SELECT * FROM pokemon").asList { row =>
  Pokemon(row.string("name"), row.short("level"), row.longOption("trainer_id"))
}
```

This would simplify both the API, and relate's code.
