### PR TITLE
Add as multimap

### DIFF
--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -59,7 +59,7 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
   def asIterable[A](parser: SqlResult => A): Iterable[A] = asCollection[A, Iterable](parser, Long.MaxValue)
   def asList[A](parser: SqlResult => A): List[A] = asCollection[A, List](parser, Long.MaxValue)
   def asMap[U, V](parser: SqlResult => (U, V)): Map[U, V] = asPairCollection[U, V, Map](parser, Long.MaxValue)
-  def asMultiMap[U, V](parser: SqlResult => (U, V)): mutable.MultiMap[U, V] = {
+  def asMultiMap[U, V](parser: SqlResult => (U, V)): Map[U, Set[V]] = {
     val mm: mutable.MultiMap[U, V] = new mutable.HashMap[U, mutable.Set[V]] with mutable.MultiMap[U, V]
     withResultSet { resultSet =>
       while (resultSet.getRow < Long.MaxValue && resultSet.next()) {
@@ -67,7 +67,7 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
         mm.addBinding(parsed._1, parsed._2)
       }
     }
-    mm
+    mm.toMap.map(x => x._1 -> x._2.toSet)
   }
 
   def asScalar[A](): A = asScalarOption.get

--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -19,6 +19,7 @@ import java.util.Date
 import java.util.UUID
 import scala.collection.JavaConversions
 import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
 import scala.collection.mutable.Builder
 import scala.collection.mutable.MutableList
 import scala.util.Try
@@ -41,7 +42,7 @@ object SqlResult {
  * methods are slightly faster, but do not do type checking or handle null values.
  */
 class SqlResult(val resultSet: java.sql.ResultSet) {
-  
+
   protected def withResultSet[A](f: (java.sql.ResultSet) => A) = {
     try {
       f(resultSet)
@@ -58,7 +59,17 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
   def asIterable[A](parser: SqlResult => A): Iterable[A] = asCollection[A, Iterable](parser, Long.MaxValue)
   def asList[A](parser: SqlResult => A): List[A] = asCollection[A, List](parser, Long.MaxValue)
   def asMap[U, V](parser: SqlResult => (U, V)): Map[U, V] = asPairCollection[U, V, Map](parser, Long.MaxValue)
-  
+  def asMultiMap[U, V](parser: SqlResult => (U, V)): mutable.MultiMap[U, V] = {
+    val mm: mutable.MultiMap[U, V] = new mutable.HashMap[U, mutable.Set[V]] with mutable.MultiMap[U, V]
+    withResultSet { resultSet =>
+      while (resultSet.getRow < Long.MaxValue && resultSet.next()) {
+        val parsed = parser(this)
+        mm.addBinding(parsed._1, parsed._2)
+      }
+    }
+    mm
+  }
+
   def asScalar[A](): A = asScalarOption.get
   def asScalarOption[A](): Option[A] = {
     if (resultSet.next()) {
@@ -100,13 +111,13 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
    * @return the current row number
    */
   def getRow(): Int = resultSet.getRow()
-  
+
   /**
    * Get the metadata for the java.sql.ResultSet that underlies this SqlResult
    * @return the metadata
    */
   def getMetaData(): ResultSetMetaData = resultSet.getMetaData()
-  
+
   /**
    * Determine if the last value extracted from the result set was null
    * @return whether the last value was null

--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -62,7 +62,7 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
   def asMultiMap[U, V](parser: SqlResult => (U, V)): Map[U, Set[V]] = {
     val mm: mutable.MultiMap[U, V] = new mutable.HashMap[U, mutable.Set[V]] with mutable.MultiMap[U, V]
     withResultSet { resultSet =>
-      while (resultSet.getRow < Long.MaxValue && resultSet.next()) {
+      while (resultSet.next()) {
         val parsed = parser(this)
         mm.addBinding(parsed._1, parsed._2)
       }

--- a/src/test/scala/SqlResultSpec.scala
+++ b/src/test/scala/SqlResultSpec.scala
@@ -131,6 +131,25 @@ class SqlResultSpec extends Specification with Mockito {
     }
   }
 
+  "asMultiMap" should {
+    "return a multimap of 2 keys with 2 entries in each" in {
+      val (rs, result) = getMocks
+      import java.lang.{Long => L}
+
+      rs.getRow returns    0 thenReturn    1 thenReturn    2 thenReturn    3 thenReturn     4
+      rs.next   returns true thenReturn true thenReturn true thenReturn true thenReturn false
+      rs.getObject("id") returns "1" thenReturns "2" thenReturns "1" thenReturns "2"
+      rs.getObject("name") returns "one" thenReturns "two" thenReturns "three" thenReturns "four"
+
+      val res = result.asMultiMap[String, String] { row =>
+        row.string("id") -> row.string("name")
+      }
+      res.keys must containTheSameElementsAs(Seq("1", "2"))
+      res("1") must containTheSameElementsAs(Seq("one", "three"))
+      res("2") must containTheSameElementsAs(Seq("two", "four"))
+    }
+  }
+
   "scalar" should {
     "return the correct type" in {
       val (rs, result) = getMocks


### PR DESCRIPTION
Example:

You have a `users` table. They all have an `id` and an `account_id`. You want to aggregate by `account_id` so you end up with a mapping from `account_id`s to a set of `user_id`s that have that `account_id` (a MultiMap). As relate currently stands, it looks something like this:

```
sql"SELECT account_id, id FROM users".asList(pairParser).foldLeft(multimap) { case (sofar, next) =>
  sofar.addBinding(next._1, next._2)
}
```

This pull request makes it so the same thing can be (more efficiently) accomplished like this:

```
sql"SELECT account_id, id FROM users".asMultiMap(pairParser)
```