### PR TITLE
Add Parseable typeclass.

### DIFF
--- a/src/main/scala/com/lucidchart/open/relate/RowParser.scala
+++ b/src/main/scala/com/lucidchart/open/relate/RowParser.scala
@@ -1,5 +1,9 @@
 package com.lucidchart.open.relate
 
+trait Parseable[A] {
+  def parse(row: SqlResult): A
+}
+
 /**
  * A RowParser is a function that takes a SqlResult as a parameter and parses it to
  * return a concrete type


### PR DESCRIPTION
this allows tying the parser implicitly to the object that a row should be parsed into:

```
case class Example(a: String, b: Int)
object Example {
  implicit val ExampleParseable = new Parseable[Example] {
    def parse(row: SqlResult) = Example(row.string("a"), row.int("b"))
  }
}
```

Then in any code that needs to query an `Example` from the database can just do the following without the need to explicitly import the parser:

```
val examples = sql"SELECT a, b FROM examples".asList[Example]
```

This will allow keeping the parsing code with the case class code while still allowing easy access to the parser. It also declutters as* calls. You are also able to deduce the type of the result without needing to manually inspect the parser that is being passed in.