### PR TITLE
Uses Parseable to parse collections

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/src/main/scala/com/lucidchart/open/relate/RowParser.scala
+++ b/src/main/scala/com/lucidchart/open/relate/RowParser.scala
@@ -1,7 +1,70 @@
 package com.lucidchart.open.relate
 
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+
 trait Parseable[A] {
   def parse(row: SqlResult): A
+}
+
+object Parseable {
+  def apply[A](f: SqlResult => A): Parseable[A] = new Parseable[A] {
+    def parse(result: SqlResult): A = f(result)
+  }
+
+  def limitedCollection[B: Parseable, Col[_]](maxRows: Long)(implicit cbf: CanBuildFrom[Col[B], B, Col[B]]) =
+    Parseable { result =>
+      val builder = cbf()
+
+      result.withResultSet { resultSet =>
+        while (resultSet.getRow < maxRows && resultSet.next()) {
+          builder += implicitly[Parseable[B]].parse(result)
+        }
+      }
+
+      builder.result
+    }
+
+  implicit def option[B: Parseable] = Parseable[Option[B]] { result =>
+    limitedCollection[B, List](1).parse(result).headOption
+  }
+
+  implicit def collection[B: Parseable, Col[_]](implicit cbf: CanBuildFrom[Col[B], B, Col[B]]) =
+    limitedCollection[B, Col](Long.MaxValue)
+
+  implicit def pairCollection[Key: Parseable, Value: Parseable, PairCol[_, _]]
+    (implicit cbf: CanBuildFrom[PairCol[Key, Value], (Key, Value), PairCol[Key, Value]]) =
+    Parseable { result =>
+
+      val builder = cbf()
+
+      result.withResultSet { resultSet =>
+        while (resultSet.getRow < Long.MaxValue && resultSet.next()) {
+          builder += implicitly[Parseable[Key]].parse(result) -> implicitly[Parseable[Value]].parse(result)
+        }
+      }
+
+      builder.result
+    }
+
+  implicit def multiMap[Key: Parseable, Value: Parseable] = Parseable[Map[Key, Set[Value]]] { result =>
+    val mm: mutable.Map[Key, Set[Value]] = new mutable.HashMap[Key, Set[Value]]
+
+    result.withResultSet { resultSet =>
+      while (resultSet.next()) {
+        val key = implicitly[Parseable[Key]].parse(result)
+        val value = implicitly[Parseable[Value]].parse(result)
+
+        mm.get(key).map { foundValue =>
+          mm += (key -> (foundValue + value))
+        }.getOrElse {
+          mm += (key -> Set(value))
+        }
+      }
+    }
+    mm.toMap
+  }
+
 }
 
 /**

--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -43,7 +43,7 @@ object SqlResult {
  */
 class SqlResult(val resultSet: java.sql.ResultSet) {
 
-  protected def withResultSet[A](f: (java.sql.ResultSet) => A) = {
+  protected[relate] def withResultSet[A](f: (java.sql.ResultSet) => A) = {
     try {
       f(resultSet)
     }
@@ -51,6 +51,8 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
       resultSet.close()
     }
   }
+
+  def as[A: Parseable](): A = implicitly[Parseable[A]].parse(this)
 
   def asSingle[A: Parseable](): A = asCollection[A, Seq](1).head
   def asSingle[A](parser: SqlResult => A): A = asCollection[A, Seq](parser, 1).head

--- a/src/test/scala/ImplicitParsingTest.scala
+++ b/src/test/scala/ImplicitParsingTest.scala
@@ -1,0 +1,159 @@
+package com.lucidchart.open.relate
+
+import java.io.ByteArrayInputStream
+import java.io.Reader
+import java.net.URL
+import java.sql.Blob
+import java.sql.Clob
+import java.sql.Clob
+import java.sql.Connection
+import java.sql.NClob
+import java.sql.Ref
+import java.sql.RowId
+import java.sql.SQLXML
+import java.sql.Time
+import java.sql.Timestamp
+import java.util.Calendar
+import java.util.Date
+import java.util.UUID
+import org.specs2.mutable._
+import org.specs2.mock.Mockito
+import scala.collection.JavaConversions
+import com.lucidchart.open.relate.SqlResultTypes._
+
+class ImplicitParsingTest extends Specification with Mockito {
+  def getMocks = {
+    val rs = mock[java.sql.ResultSet]
+    (rs, SqlResult(rs))
+  }
+
+  implicit val con: Connection = null
+
+  case class TestRecord(name: String)
+
+  object TestRecord {
+    implicit val praser = new Parseable[TestRecord] {
+      def parse(result: SqlResult): TestRecord = {
+        TestRecord(result.string("name"))
+      }
+    }
+  }
+
+  case class TestKey(key: String)
+
+  object TestKey {
+    implicit val parse = new Parseable[TestKey] {
+      def parse(result: SqlResult): TestKey = {
+        TestKey(result.string("key"))
+      }
+    }
+  }
+
+  "Parseable" should {
+    "build a list" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2
+      rs.next returns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world"
+
+      result.as[List[TestRecord]] mustEqual List(
+        TestRecord("hello"),
+        TestRecord("world")
+      )
+
+      success
+    }
+
+    "build a seq" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2
+      rs.next returns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world"
+
+      result.as[Seq[TestRecord]] mustEqual Seq(
+        TestRecord("hello"),
+        TestRecord("world")
+      )
+
+      success
+    }
+
+    "build an iterable" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2
+      rs.next returns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world"
+
+      result.as[Iterable[TestRecord]] mustEqual Iterable(
+        TestRecord("hello"),
+        TestRecord("world")
+      )
+
+      success
+    }
+
+    "build an iterable" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2
+      rs.next returns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world"
+
+      result.as[Iterable[TestRecord]] mustEqual Iterable(
+        TestRecord("hello"),
+        TestRecord("world")
+      )
+
+      success
+    }
+
+    "build a map" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2
+      rs.next returns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world"
+      rs.getObject("key") returns "1" thenReturns "2"
+
+      result.as[Map[TestKey, TestRecord]] mustEqual Map(
+        TestKey("1") -> TestRecord("hello"),
+        TestKey("2") -> TestRecord("world")
+      )
+    }
+
+    "build a multi-map" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2 thenReturns 3
+      rs.next returns true thenReturns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world" thenReturns "relate"
+      rs.getObject("key") returns "1" thenReturns "2" thenReturns "1"
+
+      result.as[Map[TestKey, Set[TestRecord]]] mustEqual Map(
+        TestKey("1") -> Set(TestRecord("hello"), TestRecord("relate")),
+        TestKey("2") -> Set(TestRecord("world"))
+      )
+    }
+
+    "build an option of something" in {
+      val (rs, result) = getMocks
+
+      rs.getRow returns 0 thenReturns 1 thenReturns 2 thenReturns 3
+      rs.next returns true thenReturns true thenReturns true thenReturns false
+      rs.getObject("name") returns "hello" thenReturns "world" thenReturns "relate"
+
+      result.as[Option[TestRecord]] mustEqual Some(TestRecord("hello"))
+    }
+
+    "build a None of something" in {
+      val (rs, result) = getMocks
+
+      rs.next returns false
+
+      result.as[Option[TestRecord]] mustEqual None
+    }
+  }
+}


### PR DESCRIPTION
This effectively renders the various `as*` methods redundant. I added a
test case that shows usage. I don't think this is 100% complete, but it
covers every scala collection with a CanBuildFrom (probably all of them)
without the need for `asList`, `asSeq`, etc. And I threw in a multiMap
for good measure.

The option parser has a weird issue. If you nest a collection parser,
you get strange behavior. I wouldn't recommend doing this. In my
"build an option of something" test case, if you change the `as` call to
`as[Option[List[TestRecord]]]` you get a result equal to
`Some(List(TestRecord("hello"), TestRecord("world")))`. I would have
expected ... something else. Either `Some(List(TestRecord("hello")))` or
`Some(List(TestRecord("hello"), TestRecord("world"),
TestRecord("relate")))`. I'm honestly not sure what the correct/expected
behavior should be here. I just know it's not returning two of three
possible rows.

I'd prefer to have comments on the option parser and reasonable solutions before we merge this.