### PR TITLE
Adds `row.column[String]` method for parsing columns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,11 @@ lazy val relate = Project(
       "-language:higherKinds"
     ),
     libraryDependencies ++= Seq(
-      "org.specs2" %% "specs2" % "2.3.12" % "test",
       "com.h2database" % "h2" % "1.4.191" % "test",
       "com.storm-enroute" %% "scalameter" % "0.7" % "bench",
       "com.storm-enroute" %% "scalameter" % "0.7" % "regression",
-      "com.typesafe.play" %% "anorm" % "2.4.0" % "bench"
+      "com.typesafe.play" %% "anorm" % "2.4.0" % "bench",
+      "org.specs2" %% "specs2" % "2.3.12" % "test"
     ),
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
     parallelExecution in Benchmark := false,

--- a/src/bench/scala/RelateBenchmarks.scala
+++ b/src/bench/scala/RelateBenchmarks.scala
@@ -31,15 +31,33 @@ object Benchmarks extends DbReport {
     }
   }
 
+  test("Selecting 1 column (alternate method)") { c =>
+    using(ranges) in { nums =>
+      c.oneColumnAlt(nums)
+    }
+  }
+
   test("Selecting 10 columns") { c =>
     using(ranges) in { nums =>
       c.tenColumns(nums)
     }
   }
 
+  test("Selecting 10 columns (alternate method)") { c =>
+    using(ranges) in { nums =>
+      c.tenColumnsAlt(nums)
+    }
+  }
+
   test("Selecting 25 columns") { c =>
     using(ranges) in { nums =>
       c.twentyFiveColumns(nums)
+    }
+  }
+
+  test("Selecting 25 columns (alternate method)") { c =>
+    using(ranges) in { nums =>
+      c.twentyFiveColumnsAlt(nums)
     }
   }
 
@@ -77,8 +95,11 @@ object Benchmarks extends DbReport {
 trait TestCase extends Serializable {
   def name: String
   def oneColumn(nums: Seq[Int])(implicit conn: Connection): List[Int]
+  def oneColumnAlt(nums: Seq[Int])(implicit conn: Connection): List[Int]
   def tenColumns(nums: Seq[Int])(implicit conn: Connection): Any
+  def tenColumnsAlt(nums: Seq[Int])(implicit conn: Connection): Any
   def twentyFiveColumns(nums: Seq[Int])(implicit conn: Connection): Any
+  def twentyFiveColumnsAlt(nums: Seq[Int])(implicit conn: Connection): Any
   def insertTen(nums: Seq[Int])(implicit conn: Connection): Any
   def insertFifty(nums: Seq[Int])(implicit conn: Connection): Any
   def updateTwo(nums: Seq[Int])(implicit conn: Connection): Any
@@ -95,6 +116,10 @@ object RelateTests extends TestCase {
     sql"SELECT col14 FROM sel_50 WHERE col44 IN ($nums)".asList(_.int("col14"))
   }
 
+  def oneColumnAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    sql"SELECT col14 FROM sel_50 WHERE col44 IN ($nums)".asList(_.column[Int]("col14"))
+  }
+
   def tenColumns(nums: Seq[Int])(implicit conn: Connection) = {
     sql"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE  `col18` IN ($nums)".asList { row =>
       row.int("col45")
@@ -108,6 +133,22 @@ object RelateTests extends TestCase {
       row.int("col3")
       row.int("col4")
       row.int("col5")
+    }
+  }
+
+  def tenColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    sql"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE  `col18` IN ($nums)".asList { row =>
+      row.column[Int]("col45")
+      row.column[Int]("col46")
+      row.column[Int]("col47")
+      row.column[Int]("col48")
+      row.column[Int]("col49")
+      row.column[Int]("col50")
+      row.column[Int]("col1")
+      row.column[Int]("col2")
+      row.column[Int]("col3")
+      row.column[Int]("col4")
+      row.column[Int]("col5")
     }
   }
 
@@ -138,6 +179,36 @@ object RelateTests extends TestCase {
       row.int("col23")
       row.int("col24")
       row.int("col25")
+    }
+  }
+
+  def twentyFiveColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    sql"SELECT `col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`,`col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,`col22`,`col23`,`col24`,`col25` FROM `sel_50` WHERE  `col18` IN ($nums)".asList { row =>
+      row.column[Int]("col1")
+      row.column[Int]("col2")
+      row.column[Int]("col3")
+      row.column[Int]("col4")
+      row.column[Int]("col5")
+      row.column[Int]("col6")
+      row.column[Int]("col7")
+      row.column[Int]("col8")
+      row.column[Int]("col9")
+      row.column[Int]("col10")
+      row.column[Int]("col11")
+      row.column[Int]("col12")
+      row.column[Int]("col13")
+      row.column[Int]("col14")
+      row.column[Int]("col15")
+      row.column[Int]("col16")
+      row.column[Int]("col17")
+      row.column[Int]("col18")
+      row.column[Int]("col19")
+      row.column[Int]("col20")
+      row.column[Int]("col21")
+      row.column[Int]("col22")
+      row.column[Int]("col23")
+      row.column[Int]("col24")
+      row.column[Int]("col25")
     }
   }
 
@@ -182,13 +253,29 @@ object AnormTests extends TestCase {
     SQL"SELECT `col14` FROM  `sel_50` WHERE `col44` IN ($nums)".as(int("col14").*)
   }
 
+  def oneColumnAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    SQL"SELECT `col14` FROM  `sel_50` WHERE `col44` IN ($nums)".as(int("col14").*)
+  }
+
   def tenColumns(nums: Seq[Int])(implicit conn: Connection) = {
     SQL"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE `col18` IN ($nums)".as(
       (int("col45")~int("col46")~int("col47")~int("col48")~int("col49")~int("col50")~int("col1")~int("col2")~int("col3")~int("col4")~int("col5")).*
     )
   }
 
+  def tenColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    SQL"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE `col18` IN ($nums)".as(
+      (int("col45")~int("col46")~int("col47")~int("col48")~int("col49")~int("col50")~int("col1")~int("col2")~int("col3")~int("col4")~int("col5")).*
+    )
+  }
+
   def twentyFiveColumns(nums: Seq[Int])(implicit conn: Connection) = {
+    SQL"SELECT `col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`,`col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,`col22`,`col23`,`col24`,`col25` FROM `sel_50`  WHERE `col18` IN ($nums)".as(
+      (int("col1")~int("col2")~int("col3")~int("col4")~int("col5")~int("col6")~int("col7")~int("col8")~int("col9")~int("col10")~int("col11")~int("col12")~int("col13")~int("col14")~int("col15")~int("col16")~int("col17")~int("col18")~int("col19")~int("col20")~int("col21")~int("col22")~int("col23")~int("col24")~int("col25")).*
+    )
+  }
+
+  def twentyFiveColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
     SQL"SELECT `col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`,`col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,`col22`,`col23`,`col24`,`col25` FROM `sel_50`  WHERE `col18` IN ($nums)".as(
       (int("col1")~int("col2")~int("col3")~int("col4")~int("col5")~int("col6")~int("col7")~int("col8")~int("col9")~int("col10")~int("col11")~int("col12")~int("col13")~int("col14")~int("col15")~int("col16")~int("col17")~int("col18")~int("col19")~int("col20")~int("col21")~int("col22")~int("col23")~int("col24")~int("col25")).*
     )
@@ -263,6 +350,27 @@ object JdbcTests extends TestCase {
     }
   }
 
+  def oneColumnAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    val queryBuilder = new StringBuilder((nums.size*2)+100,"SELECT `col14` FROM  `sel_50` WHERE `col44` IN (?" )
+    var i = 1
+    while (i < nums.size) {
+      queryBuilder.append(",?")
+      i += 1
+    }
+    queryBuilder.append(")")
+
+    withPreparedStatement(conn,  queryBuilder.toString) { statement =>
+      var i = 1
+      while (i <= nums.size) {
+        statement.setInt(i, nums(i-1))
+        i += 1
+      }
+
+      statement.executeQuery()
+      List()
+    }
+  }
+
   def tenColumns(nums: Seq[Int])(implicit conn: Connection) = {
     val queryBuilder = new StringBuilder((nums.size*2)+100,"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE  `col18` IN (?" )
     var i = 1
@@ -282,7 +390,46 @@ object JdbcTests extends TestCase {
     }
   }
 
+  def tenColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
+    val queryBuilder = new StringBuilder((nums.size*2)+100,"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE  `col18` IN (?" )
+    var i = 1
+    while (i < nums.size) {
+      queryBuilder.append(",?")
+      i += 1
+    }
+    queryBuilder.append(")")
+
+    withPreparedStatement(conn,  queryBuilder.toString) { statement =>
+      var i = 1
+      while (i <= nums.size) {
+        statement.setInt(i, nums(i-1))
+        i += 1
+      }
+      statement.executeQuery()
+    }
+  }
+
   def twentyFiveColumns(nums: Seq[Int])(implicit conn: Connection) = {
+    val queryBuilder = new StringBuilder((nums.size*2)+100,"SELECT `col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`,`col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,`col22`,`col23`,`col24`,`col25` FROM `sel_50` WHERE  `col18` IN (?" )
+    var i = 1
+    while (i < nums.size) {
+      queryBuilder.append(",?")
+      i += 1
+    }
+    queryBuilder.append(")")
+
+    withPreparedStatement(conn,  queryBuilder.toString) { statement =>
+
+      var i = 1
+      while (i <= nums.size) {
+        statement.setInt(i, nums(i-1))
+        i += 1
+      }
+      statement.executeQuery()
+    }
+  }
+
+  def twentyFiveColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
     val queryBuilder = new StringBuilder((nums.size*2)+100,"SELECT `col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`,`col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,`col22`,`col23`,`col24`,`col25` FROM `sel_50` WHERE  `col18` IN (?" )
     var i = 1
     while (i < nums.size) {

--- a/src/bench/scala/RelateBenchmarks.scala
+++ b/src/bench/scala/RelateBenchmarks.scala
@@ -117,7 +117,7 @@ object RelateTests extends TestCase {
   }
 
   def oneColumnAlt(nums: Seq[Int])(implicit conn: Connection) = {
-    sql"SELECT col14 FROM sel_50 WHERE col44 IN ($nums)".asList(_.column[Int]("col14"))
+    sql"SELECT col14 FROM sel_50 WHERE col44 IN ($nums)".asList(_[Int]("col14"))
   }
 
   def tenColumns(nums: Seq[Int])(implicit conn: Connection) = {
@@ -138,17 +138,17 @@ object RelateTests extends TestCase {
 
   def tenColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
     sql"SELECT `col45`,`col46`,`col47`,`col48`,`col49`,`col50`,`col1`,`col2`,`col3`,`col4`,`col5` FROM `sel_50` WHERE  `col18` IN ($nums)".asList { row =>
-      row.column[Int]("col45")
-      row.column[Int]("col46")
-      row.column[Int]("col47")
-      row.column[Int]("col48")
-      row.column[Int]("col49")
-      row.column[Int]("col50")
-      row.column[Int]("col1")
-      row.column[Int]("col2")
-      row.column[Int]("col3")
-      row.column[Int]("col4")
-      row.column[Int]("col5")
+      row[Int]("col45")
+      row[Int]("col46")
+      row[Int]("col47")
+      row[Int]("col48")
+      row[Int]("col49")
+      row[Int]("col50")
+      row[Int]("col1")
+      row[Int]("col2")
+      row[Int]("col3")
+      row[Int]("col4")
+      row[Int]("col5")
     }
   }
 
@@ -184,31 +184,31 @@ object RelateTests extends TestCase {
 
   def twentyFiveColumnsAlt(nums: Seq[Int])(implicit conn: Connection) = {
     sql"SELECT `col1`,`col2`,`col3`,`col4`,`col5`,`col6`,`col7`,`col8`,`col9`,`col10`,`col11`,`col12`,`col13`,`col14`,`col15`,`col16`,`col17`,`col18`,`col19`,`col20`,`col21`,`col22`,`col23`,`col24`,`col25` FROM `sel_50` WHERE  `col18` IN ($nums)".asList { row =>
-      row.column[Int]("col1")
-      row.column[Int]("col2")
-      row.column[Int]("col3")
-      row.column[Int]("col4")
-      row.column[Int]("col5")
-      row.column[Int]("col6")
-      row.column[Int]("col7")
-      row.column[Int]("col8")
-      row.column[Int]("col9")
-      row.column[Int]("col10")
-      row.column[Int]("col11")
-      row.column[Int]("col12")
-      row.column[Int]("col13")
-      row.column[Int]("col14")
-      row.column[Int]("col15")
-      row.column[Int]("col16")
-      row.column[Int]("col17")
-      row.column[Int]("col18")
-      row.column[Int]("col19")
-      row.column[Int]("col20")
-      row.column[Int]("col21")
-      row.column[Int]("col22")
-      row.column[Int]("col23")
-      row.column[Int]("col24")
-      row.column[Int]("col25")
+      row[Int]("col1")
+      row[Int]("col2")
+      row[Int]("col3")
+      row[Int]("col4")
+      row[Int]("col5")
+      row[Int]("col6")
+      row[Int]("col7")
+      row[Int]("col8")
+      row[Int]("col9")
+      row[Int]("col10")
+      row[Int]("col11")
+      row[Int]("col12")
+      row[Int]("col13")
+      row[Int]("col14")
+      row[Int]("col15")
+      row[Int]("col16")
+      row[Int]("col17")
+      row[Int]("col18")
+      row[Int]("col19")
+      row[Int]("col20")
+      row[Int]("col21")
+      row[Int]("col22")
+      row[Int]("col23")
+      row[Int]("col24")
+      row[Int]("col25")
     }
   }
 

--- a/src/main/scala/com/lucidchart/open/relate/ColReader.scala
+++ b/src/main/scala/com/lucidchart/open/relate/ColReader.scala
@@ -1,0 +1,76 @@
+package com.lucidchart.open.relate
+
+import java.nio.ByteBuffer
+import java.sql.ResultSet
+import java.util.{Date, UUID}
+
+class NullColumnException(col: String) extends Exception(s"Unexpected null value in column: $col")
+
+trait ColReader[A] { self =>
+  def read(col: String, row: SqlResult): Option[A]
+
+  def forceRead(col: String, row: SqlResult): A = {
+    read(col, row).getOrElse {
+      throw new NullColumnException(col)
+    }
+  }
+
+  def map[B](f: A => B): ColReader[B] = ColReader[B] { (col, rs) =>
+    self.read(col, rs).map(f)
+  }
+
+  def flatMap[B](f: A => ColReader[B]): ColReader[B] = ColReader[B] { (col, rs) =>
+    self.read(col, rs) match {
+      case Some(a) => f(a).read(col, rs)
+      case None => None
+    }
+  }
+
+  def filter(f: A => Boolean): ColReader[A] =
+    ColReader[A] { (col, rs) => self.read(col, rs).filter(f) }
+}
+
+object ColReader {
+  def apply[A](f: (String, SqlResult) => Option[A]): ColReader[A] = new ColReader[A] {
+    def read(col: String, rs: SqlResult): Option[A] = f(col, rs)
+  }
+
+  def option[A](x: A, rs: ResultSet): Option[A] = {
+    if (rs.wasNull()) {
+      None
+    } else {
+      Some(x)
+    }
+  }
+
+  private def optReader[A](f: (String, ResultSet) => A): ColReader[A] = ColReader[A] { (col, row) =>
+    option(f(col, row.resultSet), row.resultSet)
+  }
+
+  implicit val bigDecimalReader: ColReader[BigDecimal] = ColReader[java.math.BigDecimal] { (col, row) =>
+    option(row.resultSet.getBigDecimal(col), row.resultSet)
+  }.map(BigDecimal(_))
+
+  implicit val boolReader: ColReader[Boolean] = optReader((col, rs) => rs.getBoolean(col))
+  implicit val byteArrayReader: ColReader[Array[Byte]] = optReader((col, rs) => rs.getBytes(col))
+  implicit val byteReader: ColReader[Byte] = optReader((col, rs) => rs.getByte(col))
+  implicit val dateReader: ColReader[Date] = optReader((col, rs) => rs.getDate(col))
+  implicit val doubleReader: ColReader[Double] = optReader((col, rs) => rs.getDouble(col))
+  implicit val intReader: ColReader[Int] = optReader((col, rs) => rs.getInt(col))
+  implicit val longReader: ColReader[Long] = optReader((col, rs) => rs.getLong(col))
+  implicit val shortReader: ColReader[Short] = optReader((col, rs) => rs.getShort(col))
+  implicit val stringReader: ColReader[String] = optReader((col, rs) => rs.getString(col))
+  implicit val uuidReader: ColReader[UUID] = byteArrayReader.map { bytes =>
+    require(bytes.length == 16)
+    val bb = ByteBuffer.wrap(bytes)
+    val high = bb.getLong
+    val low = bb.getLong
+    new UUID(high, low)
+  }
+
+  def enumReader[A <: Enumeration](e: A): ColReader[e.Value] = {
+    intReader.flatMap(id => ColReader[e.Value] { (_, _) =>
+      e.values.find(_.id == id)
+    })
+  }
+}

--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -237,6 +237,11 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
     }
   }
 
+  def column[A: ColReader](col: String): A =
+    implicitly[ColReader[A]].forceRead(col, this)
+  def columnOpt[A: ColReader](col: String): Option[A] =
+    implicitly[ColReader[A]].read(col, this)
+
   def string(column: String): String = stringOption(column).get
   def stringOption(column: String): Option[String] = {
     extractOption(column) {

--- a/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
+++ b/src/main/scala/com/lucidchart/open/relate/SqlResult.scala
@@ -237,9 +237,9 @@ class SqlResult(val resultSet: java.sql.ResultSet) {
     }
   }
 
-  def column[A: ColReader](col: String): A =
+  def apply[A: ColReader](col: String): A =
     implicitly[ColReader[A]].forceRead(col, this)
-  def columnOpt[A: ColReader](col: String): Option[A] =
+  def opt[A: ColReader](col: String): Option[A] =
     implicitly[ColReader[A]].read(col, this)
 
   def string(column: String): String = stringOption(column).get

--- a/src/regression/scala/Regressions.scala
+++ b/src/regression/scala/Regressions.scala
@@ -29,6 +29,14 @@ object Regressions extends DbRegression {
       }
     }
 
+    measure method "one column (alternate method)" in {
+      using(ranges) in { nums =>
+        selectIterations.foreach { _ =>
+          RelateTests.oneColumnAlt(nums)
+        }
+      }
+    }
+
     measure method "ten columns" in {
       using(ranges) in { nums =>
         selectIterations.foreach { _ =>
@@ -37,10 +45,26 @@ object Regressions extends DbRegression {
       }
     }
 
+    measure method "ten columns (alternate method)" in {
+      using(ranges) in { nums =>
+        selectIterations.foreach { _ =>
+          RelateTests.tenColumnsAlt(nums)
+        }
+      }
+    }
+
     measure method "twenty-five columns" in {
       using(ranges) in { nums =>
         selectIterations.foreach { _ =>
           RelateTests.tenColumns(nums)
+        }
+      }
+    }
+
+    measure method "twenty-five columns (alternate method)" in {
+      using(ranges) in { nums =>
+        selectIterations.foreach { _ =>
+          RelateTests.tenColumnsAlt(nums)
         }
       }
     }

--- a/src/test/scala/ColReaderTest.scala
+++ b/src/test/scala/ColReaderTest.scala
@@ -1,0 +1,188 @@
+package com.lucidchart.open.relate
+
+import java.util.{Date, UUID}
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+
+case class RecordA(
+  bd: BigDecimal,
+  bool: Boolean,
+  ba: Array[Byte],
+  byte: Byte,
+  date: Date,
+  double: Double,
+  int: Int,
+  long: Long,
+  short: Short,
+  str: String,
+  uuid: UUID,
+  thing: Things.Value
+)
+
+object RecordA extends Mockito {
+  implicit val reader = new Parseable[RecordA] {
+    def parse(row: SqlResult): RecordA = {
+      RecordA(
+        row.column[BigDecimal]("bd"),
+        row.column[Boolean]("bool"),
+        row.column[Array[Byte]]("ba"),
+        row.column[Byte]("byte"),
+        row.column[Date]("date"),
+        row.column[Double]("double"),
+        row.column[Int]("int"),
+        row.column[Long]("long"),
+        row.column[Short]("short"),
+        row.column[String]("str"),
+        row.column[UUID]("uuid"),
+        row.column[Things.Value]("thing")
+      )
+    }
+  }
+
+  val mockRow = {
+    val rs = mock[java.sql.ResultSet]
+    rs.getBigDecimal("bd") returns new java.math.BigDecimal(10)
+    rs.getBoolean("bool") returns true
+    rs.getBytes("ba") returns Array[Byte](1,2,3)
+    rs.getByte("byte") returns (1: Byte)
+    rs.getDate("date") returns (new java.sql.Date(10000))
+    rs.getDouble("double") returns 1.1
+    rs.getInt("int") returns 10
+    rs.getLong("long") returns 100L
+    rs.getShort("short") returns (5: Short)
+    rs.getString("str") returns "hello"
+    rs.getBytes("uuid") returns Array[Byte](1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+    rs.getInt("thing") returns 1
+    SqlResult(rs)
+  }
+
+}
+
+case class RecordB(
+  bd: Option[BigDecimal],
+  bool: Option[Boolean],
+  ba: Option[Array[Byte]],
+  byte: Option[Byte],
+  date: Option[Date],
+  double: Option[Double],
+  int: Option[Int],
+  long: Option[Long],
+  short: Option[Short],
+  str: Option[String],
+  uuid: Option[UUID],
+  thing: Option[Things.Value]
+)
+
+object RecordB extends Mockito {
+  implicit val reader = new Parseable[RecordB] {
+    def parse(row: SqlResult): RecordB = {
+      RecordB(
+        row.columnOpt[BigDecimal]("bd"),
+        row.columnOpt[Boolean]("bool"),
+        row.columnOpt[Array[Byte]]("ba"),
+        row.columnOpt[Byte]("byte"),
+        row.columnOpt[Date]("date"),
+        row.columnOpt[Double]("double"),
+        row.columnOpt[Int]("int"),
+        row.columnOpt[Long]("long"),
+        row.columnOpt[Short]("short"),
+        row.columnOpt[String]("str"),
+        row.columnOpt[UUID]("uuid"),
+        row.columnOpt[Things.Value]("thing")
+      )
+    }
+  }
+
+  val mockRow = {
+    val rs = mock[java.sql.ResultSet]
+    rs.wasNull() returns true
+    rs.getBigDecimal("bd") returns null
+    rs.getBytes("ba") returns null
+    rs.getDate("date") returns null
+    rs.getString("str") returns null
+    rs.getBytes("uuid") returns null
+    SqlResult(rs)
+  }
+
+}
+
+object Things extends Enumeration {
+  val One = Value(1)
+  val Two = Value(2)
+
+  implicit val colReader: ColReader[Value] = ColReader.enumReader(this)
+}
+
+class ColReaderTest extends Specification with Mockito {
+  "ColReader" should {
+    "parse a present values" in {
+      val row = RecordA.mockRow
+      val parsed = RecordA.reader.parse(row)
+
+      // Arrays use reference equality so we have to check this
+      // independantly of all the other values
+      val bytes = parsed.ba
+      bytes === Array[Byte](1,2,3)
+
+      parsed.copy(ba = null) mustEqual RecordA(
+        BigDecimal(10),
+        true,
+        null,
+        1,
+        new Date(10000),
+        1.1,
+        10,
+        100,
+        5,
+        "hello",
+        UUID.fromString("01020304-0506-0708-090a-0b0c0d0e0f10"),
+        Things.One
+      )
+    }
+
+    "parse Nones when" in {
+      val row = RecordB.mockRow
+      val parsed = RecordB.reader.parse(row)
+
+      parsed mustEqual RecordB(
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None
+      )
+    }
+
+    "parse Somes" in {
+      val row = RecordA.mockRow
+      val parsed = RecordB.reader.parse(row)
+
+      // Arrays use reference equality so we have to check this
+      // independantly of all the other values
+      val bytes = parsed.ba.get
+      bytes === Array[Byte](1,2,3)
+
+      parsed.copy(ba = null) mustEqual RecordB(
+        Some(BigDecimal(10)),
+        Some(true),
+        null,
+        Some(1),
+        Some(new Date(10000)),
+        Some(1.1),
+        Some(10),
+        Some(100),
+        Some(5),
+        Some("hello"),
+        Some(UUID.fromString("01020304-0506-0708-090a-0b0c0d0e0f10")),
+        Some(Things.One)
+      )
+    }
+  }
+}

--- a/src/test/scala/ColReaderTest.scala
+++ b/src/test/scala/ColReaderTest.scala
@@ -23,18 +23,18 @@ object RecordA extends Mockito {
   implicit val reader = new Parseable[RecordA] {
     def parse(row: SqlResult): RecordA = {
       RecordA(
-        row.column[BigDecimal]("bd"),
-        row.column[Boolean]("bool"),
-        row.column[Array[Byte]]("ba"),
-        row.column[Byte]("byte"),
-        row.column[Date]("date"),
-        row.column[Double]("double"),
-        row.column[Int]("int"),
-        row.column[Long]("long"),
-        row.column[Short]("short"),
-        row.column[String]("str"),
-        row.column[UUID]("uuid"),
-        row.column[Things.Value]("thing")
+        row[BigDecimal]("bd"),
+        row[Boolean]("bool"),
+        row[Array[Byte]]("ba"),
+        row[Byte]("byte"),
+        row[Date]("date"),
+        row[Double]("double"),
+        row[Int]("int"),
+        row[Long]("long"),
+        row[Short]("short"),
+        row[String]("str"),
+        row[UUID]("uuid"),
+        row[Things.Value]("thing")
       )
     }
   }
@@ -77,18 +77,18 @@ object RecordB extends Mockito {
   implicit val reader = new Parseable[RecordB] {
     def parse(row: SqlResult): RecordB = {
       RecordB(
-        row.columnOpt[BigDecimal]("bd"),
-        row.columnOpt[Boolean]("bool"),
-        row.columnOpt[Array[Byte]]("ba"),
-        row.columnOpt[Byte]("byte"),
-        row.columnOpt[Date]("date"),
-        row.columnOpt[Double]("double"),
-        row.columnOpt[Int]("int"),
-        row.columnOpt[Long]("long"),
-        row.columnOpt[Short]("short"),
-        row.columnOpt[String]("str"),
-        row.columnOpt[UUID]("uuid"),
-        row.columnOpt[Things.Value]("thing")
+        row.opt[BigDecimal]("bd"),
+        row.opt[Boolean]("bool"),
+        row.opt[Array[Byte]]("ba"),
+        row.opt[Byte]("byte"),
+        row.opt[Date]("date"),
+        row.opt[Double]("double"),
+        row.opt[Int]("int"),
+        row.opt[Long]("long"),
+        row.opt[Short]("short"),
+        row.opt[String]("str"),
+        row.opt[UUID]("uuid"),
+        row.opt[Things.Value]("thing")
       )
     }
   }


### PR DESCRIPTION
The `ColReader` type class is introduced along side the
`SqlResult.column[A: ColReader]` method to allow easy extension of
supported column parsers.

`ColReader` is composable with other `ColReader`s via `map` and
`flatMap`. See `ColReader.uuidReader` and `ColReader.enumReader` for
examples.

The `ColReader`s for common types introduced here correspond roughly
with the `strictInt(col)`, `strictLong(col)`, etc. methods in
`SqlResult`.

See the tests for complete examples of usage.