### PR TITLE
Cross build with Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,11 @@ env:
     - MYSQL_USER=root
     - MYSQL_PASSWORD=
 jdk:
-  - openjdk6
+  - oraclejdk8
 language: scala
 scala:
   - 2.10.5
   - 2.11.6
+  - 2.12.1
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test package

--- a/relate/src/test/scala/ExpandableSpec.scala
+++ b/relate/src/test/scala/ExpandableSpec.scala
@@ -6,7 +6,7 @@ import org.specs2.mutable._
 
 class ExpandableSpec extends Specification {
 
-  "The expand method" should {
+  //"The expand method" should {
 
     // "work with one param" in {
     //   val query = ExpandableQuery("SELECT * FROM table WHERE id IN ({ids})").expand { implicit query =>
@@ -43,6 +43,6 @@ class ExpandableSpec extends Specification {
     //   query must_== "SELECT * FROM table WHERE id IN ({ids_0},{ids_1},{ids_2}) AND value IN ({values_0},{values_1})"
     // }
 
-  }
+  //}
 
 }

--- a/relate/src/test/scala/RelateITSpec.scala
+++ b/relate/src/test/scala/RelateITSpec.scala
@@ -4,7 +4,7 @@ import com.lucidchart.open.relate.interp._
 import com.lucidchart.open.relate.Query._
 import java.sql.{DriverManager, Connection, SQLException}
 import org.specs2.mutable._
-import org.specs2.specification.Fragments
+import org.specs2.specification.core.Fragments
 import org.specs2.specification.Step
 import java.util.Properties
 


### PR DESCRIPTION
Though we can't run benchmarks for 2.12 until a suitable anorm artifact is avaiable.