### PR TITLE
Reduce single parameter duplication with Parameterizable

### DIFF
--- a/postgres/src/main/scala/com/lucidchart/relate/postgres/package.scala
+++ b/postgres/src/main/scala/com/lucidchart/relate/postgres/package.scala
@@ -1,16 +1,15 @@
 package com.lucidchart.relate
 
+import java.sql.Types
 import org.postgresql.util.PGInterval
 import scala.concurrent.duration.FiniteDuration
-import java.sql.PreparedStatement
 
 package object postgres {
 
-  implicit class PGIntervalParameter(value: PGInterval) extends SingleParameter {
-    protected def set(stmt: PreparedStatement, i: Int) = stmt.setObject(i, value)
-  }
+  implicit val pgIntervalParameterizable =
+    Parameterizable(_.setObject(_, _: PGInterval), _.setNull(_, Types.JAVA_OBJECT))
 
-  implicit class FiniteDurationParameter(value: FiniteDuration)
-      extends PGIntervalParameter(new PGInterval(0, 0, 0, 0, 0, value.toSeconds))
+  implicit val finiteDurationParameterizable =
+    Parameterizable.from((value: FiniteDuration) => new PGInterval(0, 0, 0, 0, 0, value.toSeconds))
 
 }

--- a/relate/src/main/scala/com/lucidchart/relate/Parameterizable.scala
+++ b/relate/src/main/scala/com/lucidchart/relate/Parameterizable.scala
@@ -1,0 +1,57 @@
+package com.lucidchart.relate
+
+import java.net.URL
+import java.nio.ByteBuffer
+import java.sql._
+import java.time.{LocalDate, LocalTime}
+import java.util.UUID
+
+trait Parameterizable[-A] {
+  final def contraMap[B](f: B => A) = Parameterizable((statement, i, value: B) => set(statement, i, f(value)), setNull)
+  def set(statement: PreparedStatement, i: Int, value: A)
+  def setNull(statement: PreparedStatement, i: Int)
+  final def setOption(statement: PreparedStatement, i: Int, value: Option[A]) =
+    value.fold(setNull(statement, i))(set(statement, i, _))
+}
+
+object Parameterizable {
+  def apply[A](f: (PreparedStatement, Int, A) => Unit, g: (PreparedStatement, Int) => Unit) = new Parameterizable [A] {
+    def set(statement: PreparedStatement, i: Int, value: A) = f(statement, i, value)
+    def setNull(statement: PreparedStatement, i: Int) = g(statement, i)
+  }
+
+  def from[A, B : Parameterizable](f: A => B) = implicitly[Parameterizable[B]].contraMap(f)
+
+  implicit val array = apply(_.setArray(_, _: Array), _.setNull(_, Types.ARRAY))
+  implicit val bigDecimal = apply(_.setBigDecimal(_, _: java.math.BigDecimal), _.setNull(_, Types.DECIMAL))
+  implicit val blob = apply(_.setBlob(_, _: Blob), _.setNull(_, Types.BLOB))
+  implicit val boolean = apply(_.setBoolean(_, _: Boolean), _.setNull(_, Types.BOOLEAN))
+  implicit val byte = apply(_.setByte(_, _: Byte), _.setNull(_, Types.TINYINT))
+  implicit val bytes = apply(_.setBytes(_, _: scala.Array[Byte]), _.setNull(_, Types.VARBINARY))
+  implicit val clob = apply(_.setClob(_, _: Clob), _.setNull(_, Types.CLOB))
+  implicit val date = apply(_.setDate(_, _: Date), _.setNull(_, Types.DATE))
+  implicit val double = apply(_.setDouble(_, _: Double), _.setNull(_, Types.DOUBLE))
+  implicit val float = apply(_.setFloat(_, _: Float), _.setNull(_, Types.FLOAT))
+  implicit val int = apply(_.setInt(_, _: Int), _.setNull(_, Types.INTEGER))
+  implicit val long = apply(_.setLong(_, _: Long), _.setNull(_, Types.BIGINT))
+  implicit val nClob = apply(_.setNClob(_, _: NClob), _.setNull(_, Types.NCLOB))
+  implicit val ref = apply(_.setRef(_, _: Ref), _.setNull(_, Types.REF))
+  implicit val rowId = apply(_.setRowId(_, _: RowId), _.setNull(_, Types.ROWID))
+  implicit val short = apply(_.setShort(_, _: Short), _.setNull(_, Types.SMALLINT))
+  implicit val sqlXml = apply(_.setSQLXML(_, _: SQLXML), _.setNull(_, Types.SQLXML))
+  implicit val string = apply(_.setString(_, _: String), _.setNull(_, Types.VARCHAR))
+  implicit val time = apply(_.setTime(_, _: Time), _.setNull(_, Types.TIME))
+  implicit val timestamp = apply(_.setTimestamp(_, _: Timestamp), _.setNull(_, Types.TIMESTAMP))
+  implicit val url = apply(_.setURL(_, _: URL), _.setNull(_, Types.DATALINK))
+
+  implicit val javaDate = from((date: java.util.Date) => new Timestamp(date.getTime))
+  implicit val localDate = from(Date.valueOf(_: LocalDate))
+  implicit val localTime = from(Time.valueOf(_: LocalTime))
+  implicit val instant = from(Timestamp.from)
+  implicit val uuid = from { uuid: UUID =>
+    val bb = ByteBuffer.wrap(new scala.Array[Byte](16))
+    bb.putLong(uuid.getMostSignificantBits)
+    bb.putLong(uuid.getLeastSignificantBits)
+    bb.array
+  }
+}

--- a/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
+++ b/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
@@ -1,10 +1,6 @@
 package com.lucidchart.relate
 
-import java.net.URL
-import java.nio.ByteBuffer
-import java.sql.{Blob, Clob, Date, NClob, PreparedStatement, Ref, RowId, SQLXML, Time, Timestamp, Types}
-import java.time.{Instant, LocalDate, LocalTime}
-import java.util.UUID
+import java.sql.PreparedStatement
 import scala.language.implicitConversions
 
 /*
@@ -40,64 +36,14 @@ trait Parameter {
 }
 
 object Parameter {
-  implicit def fromArray(value: java.sql.Array) = new ArrayParameter(value)
-  implicit def fromBigDecimal(value: java.math.BigDecimal) = new BigDecimalParameter(value)
-  implicit def fromBlob(value: Blob) = new BlobParameter(value)
-  implicit def fromBoolean(value: Boolean) = new BooleanParameter(value)
-  implicit def fromByte(value: Byte) = new ByteParameter(value)
-  implicit def fromByteArray(value: Array[Byte]) = new ByteArrayParameter(value)
-  implicit def fromClob(value: Clob) = new ClobParameter(value)
-  implicit def fromDate(value: Date) = new DateParameter(value)
-  implicit def fromDouble(value: Double) = new DoubleParameter(value)
-  implicit def fromFloat(value: Float) = new FloatParameter(value)
-  implicit def fromInstant(value: Instant) = new TimestampParameter(Timestamp.from(value))
-  implicit def fromInt(value: Int) = new IntParameter(value)
-  implicit def fromLocalDate(value: LocalDate) = new DateParameter(Date.valueOf(value))
-  implicit def fromLocalTime(value: LocalTime) = new TimeParameter(Time.valueOf(value))
-  implicit def fromLong(value: Long) = new LongParameter(value)
-  implicit def fromNClob(value: NClob) = new NClobParameter(value)
-  implicit def fromRef(value: Ref) = new RefParameter(value)
-  implicit def fromRowId(value: RowId) = new RowIdParameter(value)
-  implicit def fromShort(value: Short) = new ShortParameter(value)
-  implicit def fromSqlXml(value: SQLXML) = new SqlXmlParameter(value)
-  implicit def fromString(value: String) = new StringParameter(value)
-  implicit def fromTime(value: Time) = new TimeParameter(value)
-  implicit def fromTimestamp(value: Timestamp) = new TimestampParameter(value)
-  implicit def fromUrl(value: URL) = new UrlParameter(value)
-  implicit def fromOptionalArray(value: Option[java.sql.Array]) = value.map(fromArray).getOrElse(NullArrayParameter)
-  implicit def fromOptionalBigDecimal(value: Option[java.math.BigDecimal]) = value.map(fromBigDecimal).getOrElse(NullNumericParameter)
-  implicit def fromOptionalBlob(value: Option[Blob]) = value.map(fromBlob).getOrElse(NullBlobParameter)
-  implicit def fromOptionalBoolean(value: Option[Boolean]) = value.map(fromBoolean).getOrElse(NullBooleanParameter)
-  implicit def fromOptionalByte(value: Option[Byte]) = value.map(fromByte).getOrElse(NullTinyIntParameter)
-  implicit def fromOptionalByteArray(value: Option[Array[Byte]]) = value.map(fromByteArray).getOrElse(NullVarBinaryParameter)
-  implicit def fromOptionalClob(value: Option[Clob]) = value.map(fromClob).getOrElse(NullClobParameter)
-  implicit def fromOptionalDate(value: Option[Date]) = value.map(fromDate).getOrElse(NullDateParameter)
-  implicit def fromOptionalDouble(value: Option[Double]) = value.map(fromDouble).getOrElse(NullDoubleParameter)
-  implicit def fromOptionalFloat(value: Option[Float]) = value.map(fromFloat).getOrElse(NullFloatParameter)
-  implicit def fromOptionalInstant(value: Option[Instant]) = value.map(fromInstant).getOrElse(NullTimestampParameter)
-  implicit def fromOptionalInt(value: Option[Int]) = value.map(fromInt).getOrElse(NullIntegerParameter)
-  implicit def fromOptionalLocalDate(value: LocalDate) = new DateParameter(Date.valueOf(value))
-  implicit def fromOptionalLocalTime(value: Option[LocalTime]) = value.map(fromLocalTime).getOrElse(NullTimeParameter)
-  implicit def fromOptionalLong(value: Option[Long]) = value.map(fromLong).getOrElse(NullBigIntParameter)
-  implicit def fromOptionalNClob(value: Option[NClob]) = value.map(fromNClob).getOrElse(NullNClobParameter)
-  implicit def fromOptionalRef(value: Option[Ref]) = value.map(fromRef).getOrElse(NullRefParameter)
-  implicit def fromOptionalRowId(value: Option[RowId]) = value.map(fromRowId).getOrElse(NullRowIdParameter)
-  implicit def fromOptionalShort(value: Option[Short]) = value.map(fromShort).getOrElse(NullSmallIntParameter)
-  implicit def fromOptionalSqlXml(value: Option[SQLXML]) = value.map(fromSqlXml).getOrElse(NullSqlXmlParameter)
-  implicit def fromOptionalString(value: Option[String]) = value.map(fromString).getOrElse(NullVarCharParameter)
-  implicit def fromOptionalTime(value: Option[Time]) = value.map(fromTime).getOrElse(NullTimeParameter)
-  implicit def fromOptionalTimestamp(value: Option[Timestamp]) = value.map(fromTimestamp).getOrElse(NullTimestampParameter)
-  implicit def fromOptionalUrl(value: Option[URL]) = value.map(fromUrl).getOrElse(NullDatalinkParameter)
-
-  implicit def fromJavaDate(value: java.util.Date) = fromTimestamp(new Timestamp(value.getTime))
-  implicit def fromUuid(uuid: UUID) = fromByteArray {
-    val bb = ByteBuffer.wrap(new Array[Byte](16))
-    bb.putLong(uuid.getMostSignificantBits)
-    bb.putLong(uuid.getLeastSignificantBits)
-    bb.array()
+  implicit def single[A : Parameterizable](value: A): SingleParameter = new SingleParameter {
+    protected[this] def set(statement: PreparedStatement, i: Int) =
+      implicitly[Parameterizable[A]].set(statement, i, value)
   }
-  implicit def fromOptionalJavaDate(value: Option[java.util.Date]) = value.map(fromJavaDate).getOrElse(NullTimestampParameter)
-  implicit def fromOptionalUuid(value: Option[UUID]) = value.map(fromUuid).getOrElse(NullVarBinaryParameter)
+  implicit def singleOption[A : Parameterizable](value: Option[A]): SingleParameter = new SingleParameter {
+    protected[this] def set(statement: PreparedStatement, i: Int) =
+      implicitly[Parameterizable[A]].setOption(statement, i, value)
+  }
 
   implicit def fromArray[A <% SingleParameter](it: Array[A]) = new TupleParameter(it.map(elem => elem: SingleParameter))
   implicit def fromIterable[A <% SingleParameter](it: Iterable[A]) = new TupleParameter(it.map(elem => elem: SingleParameter))
@@ -154,7 +100,7 @@ object Parameter {
 }
 
 trait SingleParameter extends Parameter {
-  protected def set(statement: PreparedStatement, i: Int)
+  protected[this] def set(statement: PreparedStatement, i: Int)
 
   def appendPlaceholders(stringBuilder: StringBuilder) = stringBuilder.append("?")
   def parameterize(statement: PreparedStatement, i: Int) = {
@@ -202,133 +148,3 @@ class TuplesParameter(val params: Iterable[TupleParameter]) extends MultiplePara
     }
   }
 }
-
-class ArrayParameter(value: java.sql.Array) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setArray(i, value)
-}
-
-class BigDecimalParameter(value: java.math.BigDecimal) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setBigDecimal(i, value)
-}
-
-class BlobParameter(value: Blob) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setBlob(i, value)
-}
-
-class BooleanParameter(value: Boolean) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setBoolean(i, value)
-}
-
-class ByteParameter(value: Byte) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setByte(i, value)
-}
-
-class ByteArrayParameter(value: Array[Byte]) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setBytes(i, value)
-}
-
-class ClobParameter(value: Clob) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setClob(i, value)
-}
-
-class DateParameter(value: Date) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setDate(i, value)
-}
-
-class DoubleParameter(value: Double) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setDouble(i, value)
-}
-
-class FloatParameter(value: Float) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setFloat(i, value)
-}
-
-class IntParameter(value: Int) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setInt(i, value)
-}
-
-class LongParameter(value: Long) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setLong(i, value)
-}
-
-class NClobParameter(value: NClob) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setNClob(i, value)
-}
-
-class RefParameter(value: Ref) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setRef(i, value)
-}
-
-class RowIdParameter(value: RowId) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setRowId(i, value)
-}
-
-class ShortParameter(value: Short) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setShort(i, value)
-}
-
-class SqlXmlParameter(value: SQLXML) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setSQLXML(i, value)
-}
-
-class StringParameter(value: String) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setString(i, value)
-}
-
-class TimeParameter(value: Time) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setTime(i, value)
-}
-
-class TimestampParameter(value: Timestamp) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setTimestamp(i, value)
-}
-
-class UrlParameter(value: URL) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setURL(i, value)
-}
-
-class NullParameter(`type`: Int) extends SingleParameter {
-  protected def set(statement: PreparedStatement, i: Int) = statement.setNull(i, `type`)
-}
-
-object NullArrayParameter extends NullParameter(Types.ARRAY)
-
-object NullBooleanParameter extends NullParameter(Types.BOOLEAN)
-
-object NullBigIntParameter extends NullParameter(Types.BIGINT)
-
-object NullBlobParameter extends NullParameter(Types.BLOB)
-
-object NullClobParameter extends NullParameter(Types.CLOB)
-
-object NullDatalinkParameter extends NullParameter(Types.DATALINK)
-
-object NullDateParameter extends NullParameter(Types.DATE)
-
-object NullDoubleParameter extends NullParameter(Types.DOUBLE)
-
-object NullFloatParameter extends NullParameter(Types.FLOAT)
-
-object NullIntegerParameter extends NullParameter(Types.INTEGER)
-
-object NullNClobParameter extends NullParameter(Types.NCLOB)
-
-object NullNumericParameter extends NullParameter(Types.NUMERIC)
-
-object NullRefParameter extends NullParameter(Types.REF)
-
-object NullRowIdParameter extends NullParameter(Types.ROWID)
-
-object NullSmallIntParameter extends NullParameter(Types.SMALLINT)
-
-object NullSqlXmlParameter extends NullParameter(Types.SQLXML)
-
-object NullTimeParameter extends NullParameter(Types.TIME)
-
-object NullTimestampParameter extends NullParameter(Types.TIMESTAMP)
-
-object NullTinyIntParameter extends NullParameter(Types.TINYINT)
-
-object NullVarBinaryParameter extends NullParameter(Types.VARBINARY)
-
-object NullVarCharParameter extends NullParameter(Types.VARCHAR)


### PR DESCRIPTION
For example `FiniteDuration` was supported with postgresql but `Option[FiniteDuration]` wasn't. Now all such parameters can easily have optional and non-optional forms.