### PR TITLE
Hide bench and regressions configurations

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,8 +7,8 @@ object Build extends AutoPlugin {
   override val trigger = allRequirements
 
   object autoImport {
-    val Benchmark = config("bench") extend Test
-    val Regression = config("regression") extend Benchmark
+    val Benchmark = config("bench").hide extend Test
+    val Regression = config("regression").hide extend Benchmark
   }
 
 }


### PR DESCRIPTION
Otherwise, they get pulled into downstream dependencies.

(There are other ways to do this, but this is an easy one.)