### PR TITLE
Fix interpolation for Array[Byte]

### DIFF
--- a/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
+++ b/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
@@ -45,6 +45,7 @@ object Parameter {
       implicitly[Parameterizable[A]].setOption(statement, i, value)
   }
 
+  implicit def fromByteArray(it: Array[Byte]) = single(it)
   implicit def fromArray[A <% SingleParameter](it: Array[A]) = new TupleParameter(it.map(elem => elem: SingleParameter))
   implicit def fromIterable[A <% SingleParameter](it: Iterable[A]) = new TupleParameter(it.map(elem => elem: SingleParameter))
   type SP = SingleParameter

--- a/relate/src/test/scala/ParameterizationTest.scala
+++ b/relate/src/test/scala/ParameterizationTest.scala
@@ -1,0 +1,20 @@
+package com.lucidchart.relate
+
+import org.specs2.mutable._
+
+class ParameterizationTest extends Specification {
+  "parameter conversions" should {
+
+    "convert Array[Byte] into a single parameter" in {
+      val byteArrayParam: Parameter = Array[Byte](5, 20, 34, 89, 110)
+      val querySql = sql"INSERT INTO myTable (foo) VALUES ($byteArrayParam)"
+      querySql.toString mustEqual("INSERT INTO myTable (foo) VALUES (?)")
+    }
+
+    "convert Array[Long] into a tuple" in {
+      val longArrayParam: Parameter = Array[Long](1l, 5l, 7l)
+      val querySql = sql"INSERT INTO myTable (foo) VALUES ($longArrayParam)"
+      querySql.toString mustEqual("INSERT INTO myTable (foo) VALUES (?,?,?)")
+    }
+  }
+}


### PR DESCRIPTION
The change that introduced `Parameterizable` and its associated implicit conversions to `SingleParameter` inadvertently changed the precedence of the implicit conversions. Now, instead of an `Array[Byte]` of size `N` being interpolated as one single parameter filled with bytes, relate accidentally interpolates it as `N` separate byte parameters within a tuple. This changes things back to the original behavior and adds a regression test to catch if this changes in the future.