### PR TITLE
Add List[Array[Byte]] and Array[Array[Byte]] tests

### DIFF
--- a/relate/src/test/scala/ParameterizationTest.scala
+++ b/relate/src/test/scala/ParameterizationTest.scala
@@ -16,5 +16,18 @@ class ParameterizationTest extends Specification {
       val querySql = sql"INSERT INTO myTable (foo) VALUES ($longArrayParam)"
       querySql.toString mustEqual("INSERT INTO myTable (foo) VALUES (?,?,?)")
     }
+
+    "convert Array[Array[Byte]] into a tuple of single parameter" in {
+      val byteArrayListParam: Parameter = Array[Array[Byte]](Array[Byte](5, 7), Array[Byte](11, 13))
+      val querySql = sql"INSERT INTO myTable (foo) VALUES ($byteArrayListParam)"
+      querySql.toString mustEqual "INSERT INTO myTable (foo) VALUES (?,?)"
+    }
+
+    "convert List[Array[Byte]] into a tuple of single parameter" in {
+      val byteArrayListParam: Parameter = List[Array[Byte]](Array[Byte](5, 7), Array[Byte](11, 13))
+      val querySql = sql"INSERT INTO myTable (foo) VALUES ($byteArrayListParam)"
+      querySql.toString mustEqual "INSERT INTO myTable (foo) VALUES (?,?)"
+    }
+
   }
 }


### PR DESCRIPTION
The conversion of a List of byte array doesn't work as expected (it did in previous versions (`2.1.1` with scala `2.12`)).

Instead of opening an issue explaining the bug I preferred to send a pull request with a couple of tests explaining it.

The first test works, the second fails.