### PR TITLE
Fix generateParser macro for case classes with more than 22 fields

### DIFF
--- a/macros/src/test/scala/com/lucidchart/open/relate/macros/RowParserTest.scala
+++ b/macros/src/test/scala/com/lucidchart/open/relate/macros/RowParserTest.scala
@@ -11,6 +11,38 @@ object Thing {
 }
 case class User(firstName: String, lastName: String)
 
+case class Big(
+  f1: Int,
+  f2: Option[Int],
+  f3: Int,
+  f4: Int,
+  f5: Int,
+  f6: Int,
+  f7: Int,
+  f8: Int,
+  f9: Int,
+  z10: Int,
+  z11: Int,
+  z12: Int,
+  z13: Int,
+  z14: Int,
+  z15: Int,
+  z16: Int,
+  z17: Int,
+  z18: Int,
+  z19: Int,
+  a20: Int,
+  a21: Int,
+  a22: Int,
+  a23: Int,
+  a24: Option[Int],
+  a25: Int
+) {
+  val m1: Int = 0
+  def m2: Int = 0
+}
+
+
 class RowParserTest extends Specification with Mockito {
   "RowParser def macros" should {
     "generate parser" in {
@@ -74,6 +106,23 @@ class RowParserTest extends Specification with Mockito {
       val row = SqlRow(rs)
 
       p.parse(row) mustEqual User("gregg", "hernandez")
+    }
+
+    "generate parser for a case class > 22 fields" in {
+      val rs = mock[java.sql.ResultSet]
+      for (i <- (1 to 9)) { rs.getInt(s"f${i}") returns i }
+      for (i <- (10 to 19)) { rs.getInt(s"z${i}") returns i }
+      for (i <- (20 to 25)) { rs.getInt(s"a${i}") returns i }
+
+      val row = SqlRow(rs)
+
+      val p = generateParser[Big]
+
+      p.parse(row) mustEqual(Big(
+        1, Some(2), 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21, 22, 23, Some(24), 25)
+      )
     }
 
     "fail to compile with non-literals" in {


### PR DESCRIPTION
Instead of looking at the signatures of the the `apply` and `unapply` methods, which don't exist for large case classes, list the case class field accessor methods to find the case class fields.

Note: I don't actually know what I'm doing with Scala macros; I just [read enough StackOverflow](https://stackoverflow.com/questions/16079113/scala-2-10-reflection-how-do-i-extract-the-field-values-from-a-case-class-i-e) to be dangerous, but this seems like a much simpler way to get the case class fields that also works for larger case classes.