### PR TITLE
Update release action to use gh instead of hub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,4 +76,4 @@ jobs:
           set -x
           tag="${GITHUB_REF#refs/tags/}"
           targets=($(printf -- "-a %s " */target/**/*.jar))
-          hub release create "${targets[@]}" -m "Release $tag" $tag
+          gh release create "$tag" -n "Release $tag" "${targets[@]}"


### PR DESCRIPTION
hub has been removed from runner images. See
https://github.com/actions/runner-images/issues/8362