### PR TITLE
Fix gh release command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,5 +75,4 @@ jobs:
         run: |
           set -x
           tag="${GITHUB_REF#refs/tags/}"
-          targets=($(printf -- "-a %s " */target/**/*.jar))
-          gh release create "$tag" -n "Release $tag" "${targets[@]}"
+          gh release create "$tag" -n "Release $tag" */target/**/*.jar


### PR DESCRIPTION
I had been confused at how the `hub` command was working, it didn't seem valid. I hadn't looked at the previous line ( :man_facepalming: ) and didn't see that `-a` was being added before each file. `-a` isn't a valid parameter for `gh release create`, you just pass the files directly. So it was failing. I'm pretty sure this should work