### PR TITLE
Update publish check to match repo name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           path: '*/target/**/*.jar'
           retention-days: 1
   publish:
-    if: github.event_name != 'pull_request' && (github.repository == 'lucidsoftware/java-thread-context')
+    if: github.event_name != 'pull_request' && (github.repository == 'lucidsoftware/relate')
     needs: build
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
I'm guessing the github actions were copied from the previously referenced repository, and the publish step wasn't updated to check for this repo.