### PR TITLE
Fix interpolation of iterables with inconsistent iteration order

### DIFF
--- a/relate/src/main/scala/com/lucidchart/relate/InterpolatedQuery.scala
+++ b/relate/src/main/scala/com/lucidchart/relate/InterpolatedQuery.scala
@@ -10,7 +10,7 @@ class InterpolatedQuery(protected val parsedQuery: String, protected val params:
 
   protected def applyParams(stmt: PreparedStatement) = parameterize(stmt, 1)
 
-  def appendPlaceholders(stringBuilder: StringBuilder) = stringBuilder ++= parsedQuery
+  def placeholder = parsedQuery
 
   def withTimeout(seconds: Int): InterpolatedQuery = new InterpolatedQuery(parsedQuery, params) {
     override protected def normalStatement(implicit conn: Connection) = new BaseStatement(conn)
@@ -37,13 +37,8 @@ class InterpolatedQuery(protected val parsedQuery: String, protected val params:
 object InterpolatedQuery {
 
   def fromParts(parts: Seq[String], params: Seq[Parameter]) = {
-    val stringBuilder = new StringBuilder()
-    parts.zip(params).foreach { case (part, param) =>
-      stringBuilder ++= part
-      param.appendPlaceholders(stringBuilder)
-    }
-    stringBuilder ++= parts.last
-    new InterpolatedQuery(stringBuilder.toString(), params)
+    val query = StringContext.standardInterpolator(identity, params.map(_.placeholder), parts)
+    new InterpolatedQuery(query, params)
   }
 
 }

--- a/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
+++ b/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
@@ -632,7 +632,9 @@ trait MultipleParameter extends Parameter {
   }
 }
 
-class TupleParameter(val params: Iterable[SingleParameter]) extends MultipleParameter {
+class TupleParameter(_params: Iterable[SingleParameter]) extends MultipleParameter {
+  // get a `Seq` to make sure placeholder and parameterize get the same ordering
+  override protected val params = _params.toSeq
   def placeholder = params.iterator.map(_.placeholder).mkString(",")
 }
 
@@ -640,6 +642,7 @@ object TupleParameter {
   def apply(params: SingleParameter*) = new TupleParameter(params)
 }
 
-class TuplesParameter(val params: Iterable[TupleParameter]) extends MultipleParameter {
+class TuplesParameter(_params: Iterable[TupleParameter]) extends MultipleParameter {
+  override protected val params = _params.toSeq
   def placeholder = if (params.isEmpty) "" else params.map(_.placeholder).mkString("(", "),(", ")")
 }

--- a/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
+++ b/relate/src/main/scala/com/lucidchart/relate/Parameters.scala
@@ -634,7 +634,9 @@ trait MultipleParameter extends Parameter {
 
 class TupleParameter(val params: Iterable[SingleParameter]) extends MultipleParameter {
   def appendPlaceholders(stringBuilder: StringBuilder) =
-    params.zipWithIndex.foreach { case (param, index) =>
+    // if we don't use the iterator, we won't necessarily get a consistent iteration order: the element with index 0
+    // according to zipWithIndex might not be the first element handled by the foreach
+    params.iterator.zipWithIndex.foreach { case (param, index) =>
       if (0 < index) {
         stringBuilder.append(",")
       }

--- a/relate/src/test/scala/ParameterizationTest.scala
+++ b/relate/src/test/scala/ParameterizationTest.scala
@@ -2,6 +2,7 @@ package com.lucidchart.relate
 
 import java.sql.PreparedStatement
 import org.specs2.mutable._
+import scala.jdk.CollectionConverters._
 
 class ParameterizationTest extends Specification {
   "parameter conversions" should {
@@ -16,6 +17,16 @@ class ParameterizationTest extends Specification {
       val longArrayParam: Parameter = Array[Long](1L, 5L, 7L)
       val querySql = sql"INSERT INTO myTable (foo) VALUES ($longArrayParam)"
       querySql.toString mustEqual "INSERT INTO myTable (foo) VALUES (?,?,?)"
+    }
+
+    "interpolate HashSets properly" in {
+      // note that HashSets don't iterate consistently: zipWithIndex and head get different "first" elements
+      // (also that zipWithIndex on a HashSet returns another HashSet)
+      val hashSet: Set[Int] = scala.collection.immutable.HashSet(1, 2, 3)
+      hashSet.zipWithIndex.head._2 mustNotEqual 0
+      // even so, we should interpolate it correctly
+      val querySql = sql"SELECT * FROM myTable WHERE id IN ($hashSet)"
+      querySql.toString mustEqual "SELECT * FROM myTable WHERE id IN (?,?,?)"
     }
   }
 

--- a/relate/src/test/scala/ParameterizationTest.scala
+++ b/relate/src/test/scala/ParameterizationTest.scala
@@ -20,11 +20,7 @@ class ParameterizationTest extends Specification {
     }
 
     "interpolate HashSets properly" in {
-      // note that HashSets don't iterate consistently: zipWithIndex and head get different "first" elements
-      // (also that zipWithIndex on a HashSet returns another HashSet)
       val hashSet: Set[Int] = scala.collection.immutable.HashSet(1, 2, 3)
-      hashSet.zipWithIndex.head._2 mustNotEqual 0
-      // even so, we should interpolate it correctly
       val querySql = sql"SELECT * FROM myTable WHERE id IN ($hashSet)"
       querySql.toString mustEqual "SELECT * FROM myTable WHERE id IN (?,?,?)"
     }
@@ -35,7 +31,7 @@ class ParameterizationTest extends Specification {
       class CustomParameter(value: Int) extends SingleParameter {
         protected[this] def set(statement: PreparedStatement, i: Int) =
           implicitly[Parameterizable[Int]].set(statement, i, value)
-        override def appendPlaceholders(stringBuilder: StringBuilder) = stringBuilder.append("?::smallint")
+        override def placeholder = "?::smallint"
       }
       val querySql = sql"INSERT INTO myTable (foo, bar) VALUES (${(1, new CustomParameter(1))})"
       querySql.toString mustEqual "INSERT INTO myTable (foo, bar) VALUES (?,?::smallint)"


### PR DESCRIPTION
primary: @jadenPete 

this will require another major version bump. `appendPlaceholders` was unwieldy and I didn't like it, and I wanted to use `mkString` for the `MultipleParameter` implementations